### PR TITLE
Fixed Controller/Keyboard Inputs not working when a Map is open

### DIFF
--- a/SRMP/Patches/Patch_PauseFix.cs
+++ b/SRMP/Patches/Patch_PauseFix.cs
@@ -70,7 +70,7 @@ namespace SRMultiplayer.Patches
                 // Save the initial state of the input
                 initialAllowInput = __instance.m_AllowGameplayInput;
 
-                // Disable input so  that we don't move when "paused"
+                // Disable input so that we don't move when "paused"
                 __instance.m_AllowGameplayInput = false;
             }
         }

--- a/SRMP/Patches/Patch_PauseFix.cs
+++ b/SRMP/Patches/Patch_PauseFix.cs
@@ -57,6 +57,17 @@ namespace SRMultiplayer.Patches
         }
     }
 
+    [HarmonyPatch(typeof(MapUI))]
+    [HarmonyPatch("OpenMap")]
+    class FIX_MapUI_OpenMap
+    {
+        static void Postfix(MapUI __instance)
+        {
+            // Fix input mode not refreshing after dying
+            SRInput.instance.SetInputMode(SRInput.InputMode.PAUSE);
+        }
+    }
+
     [HarmonyPatch(typeof(vp_FPInput))]
     [HarmonyPatch("Update")]
     class FIX_FPInput_Pause

--- a/SRMP/Patches/Patch_PauseFix.cs
+++ b/SRMP/Patches/Patch_PauseFix.cs
@@ -68,7 +68,7 @@ namespace SRMultiplayer.Patches
             prevAllowInput = __instance.m_AllowGameplayInput;
             if (Globals.IsMultiplayer && Globals.PauseState == PauseState.Pause)
             {
-                // Disable input so  that we don't move when "paused"
+                // Disable input so that we don't move when "paused"
                 __instance.m_AllowGameplayInput = false;
             }
         }

--- a/SRMP/Patches/Patch_PauseFix.cs
+++ b/SRMP/Patches/Patch_PauseFix.cs
@@ -48,12 +48,39 @@ namespace SRMultiplayer.Patches
 
             if (Globals.PauseState == PauseState.Pause)
             {
-                __instance.actions.Enabled = false;
+                __instance.actions.Enabled = true;
                 __instance.pauseActions.Enabled = true;
                 __instance.engageActions.Enabled = false;
                 return false;
             }
             return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(vp_FPInput))]
+    [HarmonyPatch("Update")]
+    class FIX_FPInput_Pause
+    {
+        private static bool prevAllowInput = false;
+
+        static void Prefix(vp_FPInput __instance)
+        {
+            prevAllowInput = __instance.m_AllowGameplayInput;
+            if (Globals.IsMultiplayer && Globals.PauseState == PauseState.Pause)
+            {
+                // Disable input so  that we don't move when "paused"
+                __instance.m_AllowGameplayInput = false;
+            }
+        }
+
+        static void Postfix(vp_FPInput __instance)
+        {
+            if (Globals.IsMultiplayer && Globals.PauseState == PauseState.Pause)
+            {
+                // Restore any initial value after we've blocked the input
+                // since I have no idea if it should have been initially disabled
+                __instance.m_AllowGameplayInput = prevAllowInput;
+            }
         }
     }
 

--- a/SRMP/Patches/Patch_PauseFix.cs
+++ b/SRMP/Patches/Patch_PauseFix.cs
@@ -61,14 +61,16 @@ namespace SRMultiplayer.Patches
     [HarmonyPatch("Update")]
     class FIX_FPInput_Pause
     {
-        private static bool prevAllowInput = false;
+        private static bool initialAllowInput = false;
 
         static void Prefix(vp_FPInput __instance)
         {
-            prevAllowInput = __instance.m_AllowGameplayInput;
             if (Globals.IsMultiplayer && Globals.PauseState == PauseState.Pause)
             {
-                // Disable input so that we don't move when "paused"
+                // Save the initial state of the input
+                initialAllowInput = __instance.m_AllowGameplayInput;
+
+                // Disable input so  that we don't move when "paused"
                 __instance.m_AllowGameplayInput = false;
             }
         }
@@ -79,7 +81,7 @@ namespace SRMultiplayer.Patches
             {
                 // Restore any initial value after we've blocked the input
                 // since I have no idea if it should have been initially disabled
-                __instance.m_AllowGameplayInput = prevAllowInput;
+                __instance.m_AllowGameplayInput = initialAllowInput;
             }
         }
     }


### PR DESCRIPTION
When you Host a multiplayer game or join one, the Map is basically broken. If you are using a Controller, there is no way to exit it or do pretty much anything, the only solution is to use your mouse. This PR fixes that.