### PR TITLE
Discord RPC support

### DIFF
--- a/SRMP.sln
+++ b/SRMP.sln
@@ -20,8 +20,8 @@ Global
 		Standalone|Any CPU = Standalone|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Debug|Any CPU.ActiveCfg = SRML|Any CPU
+		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Debug|Any CPU.Build.0 = SRML|Any CPU
 		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.SRML NoVer|Any CPU.ActiveCfg = SRML NoVer|Any CPU

--- a/SRMP.sln
+++ b/SRMP.sln
@@ -20,8 +20,8 @@ Global
 		Standalone|Any CPU = Standalone|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Debug|Any CPU.ActiveCfg = SRML|Any CPU
-		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Debug|Any CPU.Build.0 = SRML|Any CPU
+		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E1BF7CDA-F2AE-4042-A992-DCBF62E79238}.SRML NoVer|Any CPU.ActiveCfg = SRML NoVer|Any CPU

--- a/SRMP/Networking/Communication/NetworkClient.cs
+++ b/SRMP/Networking/Communication/NetworkClient.cs
@@ -13,6 +13,7 @@ namespace SRMultiplayer.Networking
 {
     public class NetworkClient : SRSingleton<NetworkClient>
     {
+        public int playerCount = 0;
         private NetClient m_Client;
 
         public enum ConnectionStatus
@@ -149,7 +150,7 @@ namespace SRMultiplayer.Networking
                                 NetIncomingMessage hail = im.SenderConnection.RemoteHailMessage;
                                 Globals.LocalID = hail.ReadByte();
 
-                                int playerCount = hail.ReadInt32();
+                                playerCount = hail.ReadInt32();
                                 for (int i = 0; i < playerCount; i++)
                                 {
                                     byte id = hail.ReadByte();

--- a/SRMP/Networking/Communication/NetworkServer.cs
+++ b/SRMP/Networking/Communication/NetworkServer.cs
@@ -1,5 +1,6 @@
 ﻿using Lidgren.Network;
 using SRMultiplayer.Packets;
+using SRMultiplayer.Plugin;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -110,7 +111,8 @@ namespace SRMultiplayer.Networking
                 SRSingleton<SceneContext>.Instance.TutorialDirector.tutModel.completedIds.Add(tut);
             }
 
-           NetworkMasterServer.Instance.CreateServer(port);
+            SRMPDiscord.InjectIntoLastRP();
+            NetworkMasterServer.Instance.CreateServer(port);
         }
 
         public void Disconnect()

--- a/SRMP/Patches/Patch_DiscordRPC.cs
+++ b/SRMP/Patches/Patch_DiscordRPC.cs
@@ -1,0 +1,24 @@
+﻿using HarmonyLib;
+using SRMultiplayer.Plugin;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SRMultiplayer.Patches
+{
+    [HarmonyPatch(typeof(DiscordRpc), nameof(DiscordRpc.UpdatePresence))]
+    static class DiscordRPCPatch
+    {
+        static void Prefix(DiscordRpc __instance, DiscordRpc.RichPresence presence)
+        {
+            if (Globals.IsMultiplayer && !SRMPDiscord.isWritting)
+                SRMPDiscord.InjectIntoRP(presence);
+        }
+        static void Postfix(DiscordRpc __instance, DiscordRpc.RichPresence presence)
+        {
+            SRMPDiscord.lastRP = presence;
+        }
+    }
+}

--- a/SRMP/Plugins/SRMPDiscord.cs
+++ b/SRMP/Plugins/SRMPDiscord.cs
@@ -25,12 +25,13 @@ namespace SRMultiplayer.Plugin
         }
         internal static void InjectIntoRP(DiscordRpc.RichPresence rp)
         {
-            rp.state += $"\nCurrently playing in multiplayer!\nLobby player count: {GetPlayerCount()}";
+            lastRP.state += $", Player {SceneContext.Instance.player.GetComponent<NetworkPlayer>().ID}\\{GetPlayerCount()}";
         }
         
         internal static void InjectIntoLastRP()
         {
-            lastRP.state += $"\nCurrently playing in multiplayer!\nLobby player count: {GetPlayerCount()}";
+            lastRP.state += $", Player {SceneContext.Instance.player.GetComponent<NetworkPlayer>().ID}\\{GetPlayerCount()}";
+
             isWritting = true;
             DiscordRpc.UpdatePresence(lastRP);
             isWritting = false;

--- a/SRMP/Plugins/SRMPDiscord.cs
+++ b/SRMP/Plugins/SRMPDiscord.cs
@@ -25,12 +25,12 @@ namespace SRMultiplayer.Plugin
         }
         internal static void InjectIntoRP(DiscordRpc.RichPresence rp)
         {
-            lastRP.state += $", Player {SceneContext.Instance.player.GetComponent<NetworkPlayer>().ID}\\{GetPlayerCount()}";
+            lastRP.state += $", Player {SceneContext.Instance.player.GetComponent<NetworkPlayer>().ID}/{GetPlayerCount()}";
         }
         
         internal static void InjectIntoLastRP()
         {
-            lastRP.state += $", Player {SceneContext.Instance.player.GetComponent<NetworkPlayer>().ID}\\{GetPlayerCount()}";
+            lastRP.state += $", Player {SceneContext.Instance.player.GetComponent<NetworkPlayer>().ID}/{GetPlayerCount()}";
 
             isWritting = true;
             DiscordRpc.UpdatePresence(lastRP);

--- a/SRMP/Plugins/SRMPDiscord.cs
+++ b/SRMP/Plugins/SRMPDiscord.cs
@@ -1,0 +1,40 @@
+﻿using SRMultiplayer.Networking;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SRMultiplayer.Plugin
+{
+    internal static class SRMPDiscord
+    {
+        internal static DiscordRpc.RichPresence lastRP;
+        public static bool isWritting;
+        public static int GetPlayerCount()
+        {
+            if (Globals.IsServer)
+            {
+                return NetworkServer.Instance.m_Server.ConnectionsCount + 1;
+            }
+            else if (Globals.IsClient)
+            {
+                return NetworkClient.Instance.playerCount;
+            }
+            else return 0;
+        }
+        internal static void InjectIntoRP(DiscordRpc.RichPresence rp)
+        {
+            rp.state += $"\nCurrently playing in multiplayer!\nLobby player count: {GetPlayerCount()}";
+        }
+        
+        internal static void InjectIntoLastRP()
+        {
+            lastRP.state += $"\nCurrently playing in multiplayer!\nLobby player count: {GetPlayerCount()}";
+            isWritting = true;
+            DiscordRpc.UpdatePresence(lastRP);
+            isWritting = false;
+        }
+
+    }
+}

--- a/SRMP/SRMP.csproj
+++ b/SRMP/SRMP.csproj
@@ -111,6 +111,10 @@
       <HintPath>.\Unity.TextMeshPro.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityCoreMod, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Slime Rancher\SlimeRancher_Data\Managed\UnityCoreMod.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine">
       <HintPath>.\UnityEngine.dll</HintPath>
       <Private>False</Private>

--- a/SRMP/SRMP.csproj
+++ b/SRMP/SRMP.csproj
@@ -94,6 +94,10 @@
       <HintPath>..\Libs\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="SRML, Version=0.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Slime Rancher\SlimeRancher_Data\Managed\SRML.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -105,11 +109,6 @@
     <Reference Include="System.Xml" />
     <Reference Include="Unity.TextMeshPro">
       <HintPath>.\Unity.TextMeshPro.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityCoreMod, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>.\UnityCoreMod.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
@@ -399,6 +398,7 @@
     <Compile Include="Patches\Patch_DecorizerStorage.cs" />
     <Compile Include="Patches\Patch_DestroyOnTouching.cs" />
     <Compile Include="Patches\Patch_DirectedActorSpawner.cs" />
+    <Compile Include="Patches\Patch_DiscordRPC.cs" />
     <Compile Include="Patches\Patch_Drone.cs" />
     <Compile Include="Patches\Patch_DroneAnimator.cs" />
     <Compile Include="Patches\Patch_DroneGadget.cs" />
@@ -482,6 +482,7 @@
     <Compile Include="Patches\Patch_WeaponVacuum.cs" />
     <Compile Include="Patches\Patch_WorldStateMasterSwitch.cs" />
     <Compile Include="Patches\Patch_ZoneDirector.cs" />
+    <Compile Include="Plugins\SRMPDiscord.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -503,11 +504,6 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'SRML|AnyCPU' ">
-    <Reference Include="SRML">
-      <HintPath>..\Libs\SRML.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="srmultiplayer.dat" />


### PR DESCRIPTION
Very simple, adds a section to the discord activity tab that displays the player ID (the index of the player) and the total server player count! Example:
![example](https://github.com/SatyPardus/srmp-public/assets/37884292/6d561e3b-4a5b-4224-91fd-2e8655b531e7)
